### PR TITLE
FR-1295 - Add cloud armor policy to be used with LB

### DIFF
--- a/beta-private-zonal-cluster/variables.tf
+++ b/beta-private-zonal-cluster/variables.tf
@@ -222,3 +222,9 @@ variable "kubernetes_version" {
     description = "Kubernetes version for the cluster"
     default = "latest"
 }
+
+variable "cloudflare_bypass_ips" {
+  description = "List of CIDR ranges to allow direct access to LB (bypassing Cloudflare)"
+  type = list(string)
+  default = null
+}


### PR DESCRIPTION
- add cloud armor policy that will be attached to LB due to K8s `securityPolicy` annotation on `BackendConfig` manifest
- always add default deny policy
- always allow traffic from Cloudflare IPs
- allow CIDR ranges in `cloudflare_bypass_ips` direct access to LB. This value defaults to `null` if not passed in by the parent module, so this rule is disabled by default. This is intended to be used for preview URLs. A limitation to this approach is that a single rule can only have up to 10 CIDR ranges. If we would need to add additional ranges, then I could create a separate rule for each value in the `cloudflare_bypass_ips` list